### PR TITLE
build: Vite - set rollup output filenames to use hash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -172,6 +172,11 @@ export default () =>
         input: {
           index: "./app/index.tsx",
         },
+        output: {
+          assetFileNames: 'assets/[name].[hash][extname]',
+          chunkFileNames: 'assets/[name].[hash].js',
+          entryFileNames: 'assets/[name].[hash].js',
+        }
       },
     },
   });


### PR DESCRIPTION
This PR explicitly sets the filenames format to `[name].[hash][ext]`.

----

Rollup 4 (Vite 5)  changed the default asset/chunk/entry filenames format to `[name]-[hash][ext]`, and the hashing algorithm is now base64. Since a base64 hash can contain `-`, bundle-stats is not able to safely extract the hash and compare the assets by filename:

<img width="1158" alt="image" src="https://github.com/vio/outline/assets/13300/cd1c8707-b4be-4eb5-a5a6-50eaf71395ce">

- [More info about bundle-stats hash extraction for Vite/Rollup](https://relative-ci.com/documentation/guides/vite-config/#use-a-common-pattern-with-content-hashes-for-filenames)
- [Rollup 5 proposed changes](https://github.com/rollup/rollup/issues/5389#issuecomment-1938251936)
